### PR TITLE
Cleanup alert status after filter has changed

### DIFF
--- a/src/main/java/de/zalando/zmon/scheduler/ng/TrialRunForwarder.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/TrialRunForwarder.java
@@ -16,8 +16,8 @@ public class TrialRunForwarder implements EntityChangeListener {
     private final Map<String, List<TrialRunRequest>> pendingTrialRuns = new HashMap<>();
 
     public void forwardRequest(TrialRunRequest trialRunRequest) {
-        synchronized(this) {
-            for(String k : pendingTrialRuns.keySet()) {
+        synchronized (this) {
+            for (String k : pendingTrialRuns.keySet()) {
                 pendingTrialRuns.get(k).add(trialRunRequest);
             }
         }
@@ -26,8 +26,8 @@ public class TrialRunForwarder implements EntityChangeListener {
     private final static List<TrialRunRequest> EMPTY_LIST = new ArrayList<>(0);
 
     public List<TrialRunRequest> getRequests(String dcId) {
-        synchronized(this) {
-            if(!pendingTrialRuns.containsKey(dcId)) {
+        synchronized (this) {
+            if (!pendingTrialRuns.containsKey(dcId)) {
                 return EMPTY_LIST;
             }
 
@@ -45,11 +45,11 @@ public class TrialRunForwarder implements EntityChangeListener {
 
     @Override
     public void notifyEntityAdd(EntityRepository repo, Entity e) {
-        if(e.getFilterProperties().get("type").equals("local")) {
+        if (e.getFilterProperties().get("type").equals("local")) {
             // local entities depict remote DCs
-            if(!pendingTrialRuns.containsKey(e.getId())) {
-                synchronized(this) {
-                    if(!pendingTrialRuns.containsKey(e.getId())) {
+            if (!pendingTrialRuns.containsKey(e.getId())) {
+                synchronized (this) {
+                    if (!pendingTrialRuns.containsKey(e.getId())) {
                         pendingTrialRuns.put(e.getId(), new ArrayList<>());
                     }
                 }
@@ -59,11 +59,11 @@ public class TrialRunForwarder implements EntityChangeListener {
 
     @Override
     public void notifyEntityRemove(EntityRepository repo, Entity e) {
-        if(e.getFilterProperties().get("type").equals("local")) {
+        if (e.getFilterProperties().get("type").equals("local")) {
             // local entities depict remote DCs
-            if(pendingTrialRuns.containsKey(e.getId())) {
-                synchronized(this) {
-                    if(pendingTrialRuns.containsKey(e.getId())) {
+            if (pendingTrialRuns.containsKey(e.getId())) {
+                synchronized (this) {
+                    if (pendingTrialRuns.containsKey(e.getId())) {
                         pendingTrialRuns.remove(e.getId());
                     }
                 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/TrialRunHttpSubscriber.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/TrialRunHttpSubscriber.java
@@ -35,7 +35,7 @@ public class TrialRunHttpSubscriber implements Runnable {
 
         LOG.info("Subscribing for trial runs: {}", url);
         this.scheduler = scheduler;
-        if(url!=null && !url.equals("")) {
+        if (url != null && !url.equals("")) {
             executor.scheduleAtFixedRate(this, 60, 5, TimeUnit.SECONDS);
         }
     }
@@ -57,8 +57,7 @@ public class TrialRunHttpSubscriber implements Runnable {
                 LOG.info("Received trial run request: {}", trialRunRequest);
                 scheduler.scheduleTrialRun(trialRunRequest);
             }
-        }
-        catch(Throwable ex) {
+        } catch (Throwable ex) {
             LOG.error("", ex);
         }
     }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertChangeListener.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertChangeListener.java
@@ -4,7 +4,7 @@ package de.zalando.zmon.scheduler.ng.alerts;
  * Created by jmussler on 4/17/15.
  */
 public interface AlertChangeListener {
-    void notifyAlertNew(AlertRepository repo, int alertId);
-    void notifyAlertChange(AlertRepository repo, int alertId);
-    void notifyAlertDelete(AlertRepository repo, int alertId);
+    void notifyAlertNew(AlertDefinition alert);
+    void notifyAlertChange(AlertDefinition alert);
+    void notifyAlertDelete(AlertDefinition alert);
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertDefinition.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertDefinition.java
@@ -254,4 +254,11 @@ public class AlertDefinition {
         sb.append('}');
         return sb.toString();
     }
+
+    public boolean compareForAlertUpdate(AlertDefinition b) {
+        // compare check id
+        // compare filter
+        // compare exclude filter
+        return false;
+    }
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertDefinition.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertDefinition.java
@@ -256,9 +256,27 @@ public class AlertDefinition {
     }
 
     public boolean compareForAlertUpdate(AlertDefinition b) {
-        // compare check id
-        // compare filter
-        // compare exclude filter
+        if (checkDefinitionId != b.checkDefinitionId) {
+            return true;
+        }
+
+        if (entities == null && b.entities != null) {
+            return true;
+        }
+
+        if (entitiesExclude == null && b.entitiesExclude != null) {
+            return true;
+        }
+
+        // we dont need to overly precise here, triggering cleanup too often, e.g. on filter/property reorder should not happen that often
+        if(entities != null && !entities.equals(b.entities)) {
+            return true;
+        }
+
+        if(entitiesExclude != null && !entitiesExclude.equals(b.entitiesExclude)) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertRepository.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertRepository.java
@@ -25,15 +25,12 @@ public class AlertRepository extends CachedRepository<Integer, AlertSourceRegist
         Map<Integer, AlertDefinition> m = new HashMap<>();
         Map<Integer, List<AlertDefinition>> newByCheckId = new HashMap<>();
 
-
-
-        for(String name : registry.getSourceNames()) {
-            for(AlertDefinition ad: registry.get(name).getCollection()) {
+        for (String name : registry.getSourceNames()) {
+            for (AlertDefinition ad : registry.get(name).getCollection()) {
                 m.put(ad.getId(), ad);
-                if(newByCheckId.containsKey(ad.getCheckDefinitionId())) {
+                if (newByCheckId.containsKey(ad.getCheckDefinitionId())) {
                     newByCheckId.get(ad.getCheckDefinitionId()).add(ad);
-                }
-                else {
+                } else {
                     List<AlertDefinition> ads = new ArrayList<>(1);
                     ads.add(ad);
                     newByCheckId.put(ad.getCheckDefinitionId(), ads);
@@ -70,10 +67,9 @@ public class AlertRepository extends CachedRepository<Integer, AlertSourceRegist
     private final static List<AlertDefinition> EMPTY_LIST = new ArrayList<>(0);
 
     public Collection<AlertDefinition> getByCheckId(Integer id) {
-        if(byCheckId.containsKey(id)) {
+        if (byCheckId.containsKey(id)) {
             return byCheckId.get(id);
-        }
-        else {
+        } else {
             return EMPTY_LIST;
         }
     }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/checks/CheckChangeListener.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/checks/CheckChangeListener.java
@@ -7,4 +7,5 @@ public interface CheckChangeListener {
     void notifyNewCheck(CheckRepository repo, int checkId);
     void notifyCheckIntervalChange(CheckRepository repo, int checkId);
     void notifyDeleteCheck(CheckRepository repo, int checkId);
+    void notifyFilterChange(int checkId);
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/checks/CheckDefinition.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/checks/CheckDefinition.java
@@ -206,4 +206,16 @@ public class CheckDefinition {
         return builder.toString();
     }
 
+    public boolean compareForCheckUpdate(CheckDefinition b) {
+        if (entities != null) {
+            return entities.equals(b.entities);
+        }
+
+        if (entities == null && b.entities != null) {
+            return true;
+        }
+
+        return false;
+    }
+
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/AlertChangeCleaner.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/AlertChangeCleaner.java
@@ -35,6 +35,7 @@ public class AlertChangeCleaner implements AlertChangeListener {
     @Bean
     @Autowired
     public static AlertChangeCleaner createCleaner(AlertRepository alertRepo, CheckRepository checkRepo, EntityRepository entityRepo, SchedulerConfig config) {
+        LOG.info("Registering alertChangeCleaner...");
         AlertChangeCleaner l = new AlertChangeCleaner(alertRepo, checkRepo, entityRepo, config);
         alertRepo.registerChangeListener(l);
         return l;
@@ -107,6 +108,8 @@ public class AlertChangeCleaner implements AlertChangeListener {
 
                 entityIdsInAlert.removeAll(matchedEntityIds);
                 entityIdsTotal.removeAll(matchedEntityIds);
+
+                LOG.info("Cleaning alertId={} checkId={} srem={} hdel={}", alertId, checkId, entityIdsInAlert.size(), entityIdsTotal.size());
 
                 Pipeline p = j.pipelined();
                 for(String e : entityIdsInAlert) {

--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/AlertChangeCleaner.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/AlertChangeCleaner.java
@@ -1,0 +1,108 @@
+package de.zalando.zmon.scheduler.ng.cleanup;
+
+import de.zalando.zmon.scheduler.ng.SchedulerConfig;
+import de.zalando.zmon.scheduler.ng.alerts.AlertChangeListener;
+import de.zalando.zmon.scheduler.ng.alerts.AlertDefinition;
+import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
+import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
+import de.zalando.zmon.scheduler.ng.entities.EntityRepository;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by jmussler on 02.06.16.
+ */
+@Component
+public class AlertChangeCleaner implements AlertChangeListener {
+
+    private final static Logger LOG = LoggerFactory.getLogger(AlertChangeListener.class);
+
+    @Bean
+    @Autowired
+    public static AlertChangeCleaner createCleaner(AlertRepository alertRepo, CheckRepository checkRepo, EntityRepository entityRepo, SchedulerConfig config) {
+        AlertChangeCleaner l = new AlertChangeCleaner(alertRepo, checkRepo, entityRepo, config);
+        alertRepo.registerChangeListener(l);
+        return l;
+    }
+
+    private final AlertRepository alertRepository;
+    private final CheckRepository checkRepository;
+    private final EntityRepository entityRepository;
+
+    private final JedisPool redisPool;
+
+    private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+
+    public AlertChangeCleaner(AlertRepository alertRepo, CheckRepository checkRepository, EntityRepository entityRepo, SchedulerConfig config) {
+        this.alertRepository = alertRepo;
+        this.checkRepository = checkRepository;
+        this.entityRepository = entityRepo;
+
+        GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+        poolConfig.setTestOnBorrow(true);
+
+        redisPool = new JedisPool(poolConfig, config.getRedis_host(), config.getRedis_port());
+    }
+
+    @Override
+    public void notifyAlertNew(AlertDefinition alert) {
+
+    }
+
+    @Override
+    public void notifyAlertChange(AlertDefinition alert) {
+        final AlertChangeCleaner c = this;
+        executor.schedule(()->c.doCleanup(alert.getId()), 90, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void notifyAlertDelete(AlertDefinition alert) {
+
+    }
+
+    public void doCleanup(int alertId) {
+        try {
+            Jedis j = redisPool.getResource();
+            try {
+                Set<String> entityIdsInAlert = new HashSet<>();
+                Set<String> entityIdsTotal = new HashSet<>();
+
+                Set<String> matchedEntityIds = new HashSet<>();
+
+                entityIdsInAlert.removeAll(matchedEntityIds);
+                entityIdsTotal.removeAll(matchedEntityIds);
+
+                final String alertKey = "zmon:alerts:" + alertId;
+                final String alertMapKey = "zmon:alerts:" + alertId + ":entities";
+
+                Pipeline p = j.pipelined();
+                for(String e : entityIdsInAlert) {
+                    p.srem(alertKey, e);
+                }
+
+                for(String e: entityIdsTotal) {
+                    p.hdel(alertMapKey, e);
+                }
+                p.sync();
+            }
+            finally {
+                j.close();
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Uncaught/Unexpected exception", t);
+        }
+    }
+}

--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/CheckChangeCleaner.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/CheckChangeCleaner.java
@@ -1,0 +1,67 @@
+package de.zalando.zmon.scheduler.ng.cleanup;
+
+import de.zalando.zmon.scheduler.ng.alerts.AlertChangeListener;
+import de.zalando.zmon.scheduler.ng.alerts.AlertDefinition;
+import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
+import de.zalando.zmon.scheduler.ng.checks.CheckChangeListener;
+import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+/**
+ * Created by jmussler on 02.06.16.
+ */
+@Component
+public class CheckChangeCleaner implements CheckChangeListener {
+
+    private final static Logger LOG = LoggerFactory.getLogger(AlertChangeListener.class);
+
+    private final AlertChangeCleaner alertCleaner;
+
+    @Bean
+    @Autowired
+    public static CheckChangeCleaner createCleaner(AlertRepository alertRepo, CheckRepository checkRepo, AlertChangeCleaner alertCleaner) {
+        LOG.info("Registering checkChangeCleaner...");
+        CheckChangeCleaner l = new CheckChangeCleaner(alertRepo, checkRepo, alertCleaner);
+        checkRepo.registerListener(l);
+        return l;
+    }
+
+    private final AlertRepository alertRepository;
+    private final CheckRepository checkRepository;
+
+    public CheckChangeCleaner(AlertRepository alertRepo, CheckRepository checkRepository, AlertChangeCleaner alertCleaner) {
+        this.alertRepository = alertRepo;
+        this.checkRepository = checkRepository;
+        this.alertCleaner = alertCleaner;
+    }
+
+    @Override
+    public void notifyNewCheck(CheckRepository repo, int checkId) {
+
+    }
+
+    @Override
+    public void notifyCheckIntervalChange(CheckRepository repo, int checkId) {
+
+    }
+
+    @Override
+    public void notifyDeleteCheck(CheckRepository repo, int checkId) {
+
+    }
+
+    @Override
+    public void notifyFilterChange(int checkId) {
+        /* Just redirect to clean up all child alerts */
+        Collection<AlertDefinition> alertDefs = alertRepository.getByCheckId(checkId);
+        for(AlertDefinition ad : alertDefs) {
+            alertCleaner.notifyAlertChange(ad);
+        }
+    }
+}

--- a/src/main/scala/de/zalando/zmon/scheduler/ng/Scheduler.scala
+++ b/src/main/scala/de/zalando/zmon/scheduler/ng/Scheduler.scala
@@ -250,6 +250,10 @@ class CheckChangedListener(val scheduler : Scheduler) extends CheckChangeListene
     Scheduler.LOG.info("Check removed or inactive: " + checkId)
     scheduler.unschedule(checkId)
   }
+
+  override def notifyFilterChange(checkId : Int) : Unit = {
+
+  }
 }
 
 @Configuration


### PR DESCRIPTION
This should remove any entities and their data if they are no longer matching the filter, til now the state becomes stale, turning blue as no longer updated.

Cleanup trigger with no actually filter change can happen, e.g. on reordering, but has no impact.
