### PR TITLE
Feature cleanup property change

### DIFF
--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/AlertChangeCleaner.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/AlertChangeCleaner.java
@@ -78,8 +78,7 @@ public class AlertChangeCleaner implements AlertChangeListener {
 
     public void doCleanup(int alertId, int checkId) {
         try {
-            Jedis j = redisPool.getResource();
-            try {
+            try (Jedis j = redisPool.getResource()) {
 
                 final String alertKey = "zmon:alerts:" + alertId;
                 final String alertMapKey = "zmon:alerts:" + alertId + ":entities";
@@ -103,8 +102,6 @@ public class AlertChangeCleaner implements AlertChangeListener {
                     p.hdel(alertMapKey, e);
                 }
                 p.sync();
-            } finally {
-                j.close();
             }
         } catch (Throwable t) {
             LOG.error("Uncaught/Unexpected exception: msg={} check_id={} alert_id={}", t, checkId, alertId);

--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/CleanupConfiguration.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/CleanupConfiguration.java
@@ -3,6 +3,7 @@ package de.zalando.zmon.scheduler.ng.cleanup;
 import de.zalando.zmon.scheduler.ng.SchedulerConfig;
 import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
 import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
+import de.zalando.zmon.scheduler.ng.entities.EntityChangeListener;
 import de.zalando.zmon.scheduler.ng.entities.EntityRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,15 @@ public class CleanupConfiguration {
         LOG.info("Registering alertChangeCleaner...");
         AlertChangeCleaner l = new AlertChangeCleaner(alertRepo, checkRepo, entityRepo, config);
         alertRepo.registerChangeListener(l);
+        return l;
+    }
+
+    @Bean
+    @Autowired
+    public EntityChangedCleaner entityChangedCleaner(EntityRepository entityRepo, AlertRepository alertRepo, CheckRepository checkRepo, AlertChangeCleaner alertCleaner) {
+        LOG.info("Registering entityChangedCleaner...");
+        EntityChangedCleaner l = new EntityChangedCleaner(alertRepo, checkRepo, alertCleaner);
+        entityRepo.registerListener(l);
         return l;
     }
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/EntityChangedCleaner.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/EntityChangedCleaner.java
@@ -74,6 +74,10 @@ public class EntityChangedCleaner implements EntityChangeListener {
 
     }
 
+    protected void notifyEntityChangeNoWait(EntityRepository repo, Entity entityOld, Entity entityNew) {
+        executor.schedule(new EntityChangeCleanupTask(entityOld, entityNew), 0, TimeUnit.SECONDS);
+    }
+
     @Override
     public void notifyEntityChange(EntityRepository repo, Entity entityOld, Entity entityNew) {
         executor.schedule(new EntityChangeCleanupTask(entityOld, entityNew), 5, TimeUnit.SECONDS);

--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/EntityChangedCleaner.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/EntityChangedCleaner.java
@@ -1,37 +1,66 @@
 package de.zalando.zmon.scheduler.ng.cleanup;
 
-import de.zalando.zmon.scheduler.ng.SchedulerConfig;
+import de.zalando.zmon.scheduler.ng.AlertOverlapGenerator;
+import de.zalando.zmon.scheduler.ng.alerts.AlertDefinition;
 import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
+import de.zalando.zmon.scheduler.ng.checks.CheckDefinition;
 import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
 import de.zalando.zmon.scheduler.ng.entities.Entity;
 import de.zalando.zmon.scheduler.ng.entities.EntityChangeListener;
 import de.zalando.zmon.scheduler.ng.entities.EntityRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by jmussler on 06.06.16.
  */
 public class EntityChangedCleaner implements EntityChangeListener {
 
+    private final static Logger LOG = LoggerFactory.getLogger(EntityChangedCleaner.class);
+
     private final AlertRepository alertRepo;
     private final CheckRepository checkRepo;
     private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-    private final SchedulerConfig config;
+    private final AlertChangeCleaner alertCleaner;
 
-    public EntityChangedCleaner(AlertRepository alertRepo, CheckRepository checkRepo, SchedulerConfig config) {
+    public EntityChangedCleaner(AlertRepository alertRepo, CheckRepository checkRepo, AlertChangeCleaner alertCleaner) {
         this.alertRepo = alertRepo;
         this.checkRepo = checkRepo;
-        this.config = config;
+        this.alertCleaner = alertCleaner;
     }
 
-    private class EntityChangeCleanupTask {
+    private class EntityChangeCleanupTask implements Runnable {
         private final Entity oldEntity;
         private final Entity newEntity;
 
         public EntityChangeCleanupTask(Entity oldEntity, Entity newEntity) {
             this.oldEntity = oldEntity;
             this.newEntity = newEntity;
+        }
+
+        @Override
+        public void run() {
+            try {
+                for(CheckDefinition cd : checkRepo.get()) {
+                    if(AlertOverlapGenerator.matchCheckFilter(cd, oldEntity)) {
+                        for(AlertDefinition ad : alertRepo.getByCheckId(cd.getId())) {
+                            if(AlertOverlapGenerator.matchAlertFilter(ad, oldEntity)) {
+                                if(!AlertOverlapGenerator.matchCheckFilter(cd, newEntity)
+                                        || !AlertOverlapGenerator.matchAlertFilter(ad, newEntity)) {
+                                    // reuse code, this cleans up all non matching entities
+                                    alertCleaner.notifyAlertChange(ad);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Throwable t) {
+                LOG.error("Failed to cleanup changed entity: id={}", newEntity.getId());
+            }
         }
     }
 
@@ -47,6 +76,7 @@ public class EntityChangedCleaner implements EntityChangeListener {
 
     @Override
     public void notifyEntityChange(EntityRepository repo, Entity entityOld, Entity entityNew) {
-
+        executor.schedule(new EntityChangeCleanupTask(entityOld, entityNew), 5, TimeUnit.SECONDS);
+        executor.schedule(new EntityChangeCleanupTask(entityOld, entityNew), 60, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/EntityChangedCleaner.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/EntityChangedCleaner.java
@@ -44,11 +44,11 @@ public class EntityChangedCleaner implements EntityChangeListener {
         @Override
         public void run() {
             try {
-                for(CheckDefinition cd : checkRepo.get()) {
-                    if(AlertOverlapGenerator.matchCheckFilter(cd, oldEntity)) {
-                        for(AlertDefinition ad : alertRepo.getByCheckId(cd.getId())) {
-                            if(AlertOverlapGenerator.matchAlertFilter(ad, oldEntity)) {
-                                if(!AlertOverlapGenerator.matchCheckFilter(cd, newEntity)
+                for (CheckDefinition cd : checkRepo.get()) {
+                    if (AlertOverlapGenerator.matchCheckFilter(cd, oldEntity)) {
+                        for (AlertDefinition ad : alertRepo.getByCheckId(cd.getId())) {
+                            if (AlertOverlapGenerator.matchAlertFilter(ad, oldEntity)) {
+                                if (!AlertOverlapGenerator.matchCheckFilter(cd, newEntity)
                                         || !AlertOverlapGenerator.matchAlertFilter(ad, newEntity)) {
                                     // reuse code, this cleans up all non matching entities
                                     alertCleaner.notifyAlertChange(ad);
@@ -57,8 +57,7 @@ public class EntityChangedCleaner implements EntityChangeListener {
                         }
                     }
                 }
-            }
-            catch (Throwable t) {
+            } catch (Throwable t) {
                 LOG.error("Failed to cleanup changed entity: id={}", newEntity.getId());
             }
         }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/entities/EntityRepository.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/entities/EntityRepository.java
@@ -36,7 +36,7 @@ public class EntityRepository extends CachedRepository<String, EntityAdapterRegi
     private String redis_properties_key = null;
 
     public synchronized void registerListener(EntityChangeListener l) {
-        LOG.info("Registering entity change listener ({}, {})", l.getClass(), currentMap.size());
+        LOG.info("Registering entity change listener: type={} count={}", l.getClass().getCanonicalName(), currentMap.size());
         Map<String, Entity> m = unfilteredEntities;
         for (String k : m.keySet()) {
             l.notifyEntityAdd(this, m.get(k));
@@ -80,12 +80,11 @@ public class EntityRepository extends CachedRepository<String, EntityAdapterRegi
 
             ObjectMapper mapper = new ObjectMapper();
             String v = mapper.writeValueAsString(typeMap);
-            Jedis jedis = redisPool.getResource();
-            try {
+
+            try (Jedis jedis = redisPool.getResource()) {
                 jedis.set(redis_properties_key.getBytes(), Snappy.compress(v.getBytes("UTF-8")));
-            } finally {
-                jedis.close();
             }
+
             LOG.info("Done writing auto complete data for front end");
         } catch (Exception ex) {
             LOG.error("Error during generating auto complete data");

--- a/src/test/java/de/zalando/zmon/scheduler/ng/FilterTest.java
+++ b/src/test/java/de/zalando/zmon/scheduler/ng/FilterTest.java
@@ -1,0 +1,91 @@
+package de.zalando.zmon.scheduler.ng;
+
+import de.zalando.zmon.scheduler.ng.alerts.AlertDefinition;
+import de.zalando.zmon.scheduler.ng.checks.CheckDefinition;
+import de.zalando.zmon.scheduler.ng.entities.Entity;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by jmussler on 08.06.16.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FilterTest {
+
+    AlertDefinition emptyAlerty = when(mock(AlertDefinition.class).getId()).thenReturn(1).getMock();
+
+    CheckDefinition emptyCheck = when(mock(CheckDefinition.class).getId()).thenReturn(1).getMock();
+
+    private final static Map<String, Object> simpleEntityProperties = new HashMap<String , Object>() {{
+        put("id",  "entity-1");
+        put("type", "host");
+        put("application", "zmon-scheduler");
+    }};
+
+    private final static Map<String, String> typeHostFilter = new HashMap<String , String>() {{
+        put("type", "host");
+    }};
+
+    private final static Map<String, String> typeApplicationFilter = new HashMap<String , String>() {{
+        put("type", "application");
+    }};
+
+    Entity simpleEntity = when(mock(Entity.class).getFilterProperties()).thenReturn(simpleEntityProperties).getMock();
+
+    CheckDefinition hostCheck = when(mock(CheckDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
+
+    CheckDefinition applicationCheck = when(mock(CheckDefinition.class).getEntities()).thenReturn(asList(typeApplicationFilter)).getMock();
+
+    CheckDefinition bothCheck = when(mock(CheckDefinition.class).getEntities()).thenReturn(asList(typeApplicationFilter, typeHostFilter)).getMock();
+
+    AlertDefinition hostAlert = when(mock(AlertDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
+
+    AlertDefinition applicationAlert = when(mock(AlertDefinition.class).getEntities()).thenReturn(asList(typeApplicationFilter)).getMock();
+
+    AlertDefinition bothAlert = when(mock(AlertDefinition.class).getEntities()).thenReturn(asList(typeApplicationFilter, typeHostFilter)).getMock();
+
+    @Test
+    public void testEmptyAlertFilter() {
+        boolean matchesEmptyAlert = AlertOverlapGenerator.matchAlertFilter(emptyAlerty, simpleEntity);
+        assertEquals(true, matchesEmptyAlert);
+    }
+
+    @Test
+    public void testEmptyCheck() {
+        boolean matchesEmptyCheck = AlertOverlapGenerator.matchCheckFilter(emptyCheck, simpleEntity);
+        assertEquals(false, matchesEmptyCheck);
+    }
+
+    @Test
+    public void testCheckFilterMatch() {
+        boolean matchHostCheck = AlertOverlapGenerator.matchCheckFilter(hostCheck, simpleEntity);
+        assertEquals(true, matchHostCheck);
+
+        boolean matchApplicationCheck = AlertOverlapGenerator.matchCheckFilter(applicationCheck, simpleEntity);
+        assertEquals(false, matchApplicationCheck);
+
+        boolean matchBothCheck = AlertOverlapGenerator.matchCheckFilter(bothCheck, simpleEntity);
+        assertEquals(true, matchBothCheck);
+    }
+
+    @Test
+    public void testAlertFilterMatch() {
+        boolean matchHostAlert = AlertOverlapGenerator.matchAlertFilter(hostAlert, simpleEntity);
+        assertEquals(true, matchHostAlert);
+
+        boolean matchApplicationAlert = AlertOverlapGenerator.matchAlertFilter(applicationAlert, simpleEntity);
+        assertEquals(false, matchApplicationAlert);
+
+        boolean matchBothAlert = AlertOverlapGenerator.matchAlertFilter(bothAlert, simpleEntity);
+        assertEquals(true, matchBothAlert);
+    }
+}

--- a/src/test/java/de/zalando/zmon/scheduler/ng/SchedulerTest.java
+++ b/src/test/java/de/zalando/zmon/scheduler/ng/SchedulerTest.java
@@ -8,17 +8,13 @@ import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
 import de.zalando.zmon.scheduler.ng.entities.Entity;
 import de.zalando.zmon.scheduler.ng.entities.EntityRepository;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.mockito.AdditionalMatchers.gt;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/de/zalando/zmon/scheduler/ng/cleanup/EntityPropertyChangeTest.java
+++ b/src/test/java/de/zalando/zmon/scheduler/ng/cleanup/EntityPropertyChangeTest.java
@@ -4,18 +4,22 @@ import de.zalando.zmon.scheduler.ng.alerts.AlertDefinition;
 import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
 import de.zalando.zmon.scheduler.ng.checks.CheckDefinition;
 import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
-import de.zalando.zmon.scheduler.ng.cleanup.AlertChangeCleaner;
-import de.zalando.zmon.scheduler.ng.cleanup.EntityChangedCleaner;
 import de.zalando.zmon.scheduler.ng.entities.Entity;
-import de.zalando.zmon.scheduler.ng.entities.EntityChangeListener;
+import de.zalando.zmon.scheduler.ng.entities.EntityRepository;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.reset;
 
 /**
  * Created by jmussler on 08.06.16.
@@ -38,20 +42,40 @@ public class EntityPropertyChangeTest {
         put("type", "host");
     }};
 
-    Entity simpleEntity = when(mock(Entity.class).getFilterProperties()).thenReturn(simpleEntityProperties).getMock();
-    Entity simpleEntityChanged = when(mock(Entity.class).getFilterProperties()).thenReturn(simpleEntityPropertiesChanged).getMock();
+    static CheckDefinition hostCheck = when(mock(CheckDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
+    static AlertDefinition hostAlert = when(mock(AlertDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
 
-    CheckDefinition hostCheck = when(mock(CheckDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
+    static AlertRepository alertRepo = mock(AlertRepository.class);
+    static CheckRepository checkRepo = mock(CheckRepository.class);
+    static EntityRepository entityRepo = mock(EntityRepository.class);
 
-    AlertDefinition hostAlert = when(mock(AlertDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
+    static AlertChangeCleaner alertCleaner = mock(AlertChangeCleaner.class);
+    static EntityChangedCleaner cleaner = new EntityChangedCleaner(alertRepo, checkRepo, alertCleaner);
+
+    static Entity simpleEntity = when(mock(Entity.class).getFilterProperties()).thenReturn(simpleEntityProperties).getMock();
+    static Entity simpleEntityChanged = when(mock(Entity.class).getFilterProperties()).thenReturn(simpleEntityPropertiesChanged).getMock();
+
+    @BeforeClass
+    public static void setupMocks() {
+        when(hostCheck.getId()).thenReturn(1);
+        when(hostAlert.getId()).thenReturn(1);
+        when(hostAlert.getCheckDefinitionId()).thenReturn(1);
+
+        when(checkRepo.get()).thenReturn(asList(hostCheck));
+        when(alertRepo.getByCheckId(anyInt())).thenReturn(asList(hostAlert));
+    }
 
     @Test
     public void testTrigger() {
-        AlertRepository alertRepo = mock(AlertRepository.class);
-        CheckRepository checkRepo = mock(CheckRepository.class);
-        AlertChangeCleaner alertCleaner = mock(AlertChangeCleaner.class);
-        EntityChangedCleaner cleaner = new EntityChangedCleaner(alertRepo, checkRepo, alertCleaner);
-        cleaner.no
+        reset(alertCleaner);
+        cleaner.notifyEntityChangeNoWait(entityRepo, simpleEntity, simpleEntityChanged);
+        verify(alertCleaner, timeout(1000).times(1)).notifyAlertChange(hostAlert);
+    }
 
+    @Test
+    public void testNoTrigger() {
+        reset(alertCleaner);
+        cleaner.notifyEntityChangeNoWait(entityRepo, simpleEntity, simpleEntity);
+        verify(alertCleaner, Mockito.after(1000).atMost(0)).notifyAlertChange(hostAlert);
     }
 }

--- a/src/test/java/de/zalando/zmon/scheduler/ng/cleanup/EntityPropertyChangeTest.java
+++ b/src/test/java/de/zalando/zmon/scheduler/ng/cleanup/EntityPropertyChangeTest.java
@@ -1,0 +1,57 @@
+package de.zalando.zmon.scheduler.ng.cleanup;
+
+import de.zalando.zmon.scheduler.ng.alerts.AlertDefinition;
+import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
+import de.zalando.zmon.scheduler.ng.checks.CheckDefinition;
+import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
+import de.zalando.zmon.scheduler.ng.cleanup.AlertChangeCleaner;
+import de.zalando.zmon.scheduler.ng.cleanup.EntityChangedCleaner;
+import de.zalando.zmon.scheduler.ng.entities.Entity;
+import de.zalando.zmon.scheduler.ng.entities.EntityChangeListener;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by jmussler on 08.06.16.
+ */
+public class EntityPropertyChangeTest {
+
+    private final static Map<String, Object> simpleEntityProperties = new HashMap<String , Object>() {{
+        put("id",  "entity-1");
+        put("type", "host");
+        put("application", "zmon-scheduler");
+    }};
+
+    private final static Map<String, Object> simpleEntityPropertiesChanged = new HashMap<String , Object>() {{
+        put("id",  "entity-1");
+        put("type", "application");
+        put("application", "zmon-scheduler");
+    }};
+
+    private final static Map<String, String> typeHostFilter = new HashMap<String , String>() {{
+        put("type", "host");
+    }};
+
+    Entity simpleEntity = when(mock(Entity.class).getFilterProperties()).thenReturn(simpleEntityProperties).getMock();
+    Entity simpleEntityChanged = when(mock(Entity.class).getFilterProperties()).thenReturn(simpleEntityPropertiesChanged).getMock();
+
+    CheckDefinition hostCheck = when(mock(CheckDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
+
+    AlertDefinition hostAlert = when(mock(AlertDefinition.class).getEntities()).thenReturn(asList(typeHostFilter)).getMock();
+
+    @Test
+    public void testTrigger() {
+        AlertRepository alertRepo = mock(AlertRepository.class);
+        CheckRepository checkRepo = mock(CheckRepository.class);
+        AlertChangeCleaner alertCleaner = mock(AlertChangeCleaner.class);
+        EntityChangedCleaner cleaner = new EntityChangedCleaner(alertRepo, checkRepo, alertCleaner);
+        cleaner.no
+
+    }
+}


### PR DESCRIPTION
Removes entities if they do change and no longer match the check or alert filter.

So far properties have been pretty static, but e.g. dns_traffic field changes on AWS.
