### PR TITLE
use Alpine Linux base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-26
+FROM registry.opensource.zalan.do/stups/openjdk:8-2-alpine
 
 EXPOSE 8085
 


### PR DESCRIPTION
Switch from Ubuntu to Alpine base image to save space.

Size comparison:

```
registry.opensource.zalan.do/stups/openjdk 8-2-alpine        152.2 MB
registry.opensource.zalan.do/stups/openjdk 8-26              515.9 MB
```

I tested it locally including SSL verification.
