### PR TITLE
fix warning "Inconsistent constructor declaration on bean with name"

### DIFF
--- a/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertSourceRegistry.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/alerts/AlertSourceRegistry.java
@@ -22,7 +22,7 @@ public class AlertSourceRegistry extends SourceRegistry<AlertSource> {
         this.metrics = metrics;
     }
 
-    @Autowired(required = false)
+    @Autowired
     public AlertSourceRegistry(final SchedulerConfig config, final MetricRegistry metrics, final TokenWrapper tokens, ClientHttpRequestFactory clientFactory) {
         this.metrics = metrics;
 

--- a/src/main/java/de/zalando/zmon/scheduler/ng/checks/CheckSourceRegistry.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/checks/CheckSourceRegistry.java
@@ -16,7 +16,7 @@ public class CheckSourceRegistry extends SourceRegistry<CheckSource> {
 
     }
 
-    @Autowired(required = false)
+    @Autowired
     public CheckSourceRegistry(SchedulerConfig config, final TokenWrapper tokens, ClientHttpRequestFactory clientFactory) {
         final String url = config.controller_url() + (config.urls_without_rest() ? "" : "/rest") + "/api/v1/checks/all-active-check-definitions";
         final DefaultCheckSource source = new DefaultCheckSource("check-source", url, tokens, clientFactory);


### PR DESCRIPTION
This is only removing the following warning messages during startup:

```
2016-06-24 16:53:07.364  WARN 29901 --- [           main] f.a.AutowiredAnnotationBeanPostProcessor : Inconsistent constructor declaration on bean with name 'checkSourceRegistry': single autowire-marked constructor flagged as optional - t
his constructor is effectively required since there is no default constructor to fall back to: public de.zalando.zmon.scheduler.ng.checks.CheckSourceRegistry(de.zalando.zmon.scheduler.ng.SchedulerConfig,de.zalando.zmon.scheduler.ng.Token
Wrapper,org.springframework.http.client.ClientHttpRequestFactory)
```
