### PR TITLE
Improving Downtimes

### DIFF
--- a/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/DowntimeCleanup.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/cleanup/DowntimeCleanup.java
@@ -1,0 +1,84 @@
+package de.zalando.zmon.scheduler.ng.cleanup;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import de.zalando.zmon.scheduler.ng.config.SchedulerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by jmussler on 13.12.16.
+ */
+public class DowntimeCleanup implements Runnable {
+
+    private final Logger log = LoggerFactory.getLogger(DowntimeCleanup.class);
+    private final SchedulerConfig config;
+    private final ObjectMapper mapper = (new ObjectMapper()).setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+    private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+
+    public DowntimeCleanup(SchedulerConfig config) {
+        this.config = config;
+        executor.scheduleAtFixedRate(this, 5, 15, TimeUnit.MINUTES);
+    }
+
+    // not pipelining on purpose, this is just background task, dont want to block
+    // just deleting entries not valid any more. Cleaning up upper level entries is done on next iteration
+    private void doCleanup() {
+        long now = System.currentTimeMillis() / 1000L;
+
+        try(Jedis jedis = new Jedis(config.getRedisHost(), config.getRedisPort())) {
+            Set<String> alertIdsInDowntime = jedis.smembers("zmon:downtimes");
+            log.info("Alerts in downtime: count={}", alertIdsInDowntime.size());
+            int cleanupCounter = 0;
+            for(String alertId : alertIdsInDowntime) {
+                Set<String> entityIds = jedis.smembers("zmon:downtimes:" + alertId);
+                if (null == entityIds) {
+                    cleanupCounter++;
+                    jedis.srem("zmon:downtimes", alertId);
+                }
+
+                for(String entityId : entityIds) {
+                    Map<String, String> downtimes = jedis.hgetAll("zmon:downtimes:" + alertId + ":" + entityId);
+                    if(null == downtimes) {
+                        cleanupCounter++;
+                        jedis.srem("zmon:downtimes:" + alertId, entityId);
+                    }
+
+                    for(Map.Entry<String, String> dt  : downtimes.entrySet()) {
+                        try {
+                            JsonNode d = mapper.readTree(dt.getValue());
+                            if(d.has("end_time") && Long.compare(now, d.get("end_time").asLong()) >= 0) {
+                                jedis.hdel("zmon:downtimes:" + alertId + ":" + entityId, dt.getKey());
+                                cleanupCounter++;
+                            }
+                        }
+                        catch(IOException ex) {
+                            // malformed json redis, delete downtime entry
+                            log.info("Failed to read downtime: entity={} id={}", entityId, dt.getKey());
+                            jedis.hdel("zmon:downtimes:" + alertId + ":" + entityId, dt.getKey());
+                        }
+                    }
+                }
+            }
+            log.info("Cleanup downtimes ended: count={}", cleanupCounter);
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            doCleanup();
+        }
+        catch(Throwable t) {
+            log.error("Cleanup downtimes failed", t);
+        }
+    }
+}

--- a/src/main/java/de/zalando/zmon/scheduler/ng/config/CleanupConfiguration.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/config/CleanupConfiguration.java
@@ -1,11 +1,8 @@
 package de.zalando.zmon.scheduler.ng.config;
 
-import de.zalando.zmon.scheduler.ng.cleanup.AlertChangedCleaner;
-import de.zalando.zmon.scheduler.ng.cleanup.CheckChangedCleaner;
-import de.zalando.zmon.scheduler.ng.cleanup.EntityChangedCleaner;
+import de.zalando.zmon.scheduler.ng.cleanup.*;
 import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
 import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
-import de.zalando.zmon.scheduler.ng.cleanup.MetricsCleanup;
 import de.zalando.zmon.scheduler.ng.entities.EntityRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +45,13 @@ public class CleanupConfiguration {
     public MetricsCleanup metricsCleanup(SchedulerConfig config) {
         LOG.info("Registering metricsCleaner...");
         MetricsCleanup cleaner = new MetricsCleanup(config);
+        return cleaner;
+    }
+
+    @Bean
+    public DowntimeCleanup downtimeCleanup(SchedulerConfig config){
+        LOG.info("Registering downtimeCleanup...");
+        DowntimeCleanup cleaner = new DowntimeCleanup(config);
         return cleaner;
     }
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/downtimes/DowntimeHttpSubscriber.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/downtimes/DowntimeHttpSubscriber.java
@@ -56,11 +56,11 @@ public class DowntimeHttpSubscriber implements Runnable {
                         service.storeDowntime(task.getRequest());
                         break;
                     case DELETE:
-                        LOG.info("Received downtime request: type={} ids={}", task.getType(), task.getIds());
+                        LOG.info("Received downtime delete request: type={} ids={}", task.getType(), task.getIds());
                         service.deleteDowntimes(task.getIds());
                         break;
                     case DELETE_GROUP:
-                        LOG.info("Received downtime request: type={} (unexpected)", task.getType());
+                        LOG.info("Received downtime group delete request: type={} (unexpected)", task.getType());
                         service.deleteDowntimeGroup(task.getGroupId());
                         break;
                 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/downtimes/DowntimeService.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/downtimes/DowntimeService.java
@@ -7,10 +7,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +37,8 @@ public class DowntimeService {
     private final SchedulerConfig config;
     private final EntityRepository entityRepository;
     private final boolean enableEntityFilter;
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Autowired
     public DowntimeService(SchedulerConfig config, EntityRepository entityRepository) {
@@ -119,10 +125,8 @@ For now do a very stupid delete, we just assume that the id is present and delet
 */
 
     public void deleteDowntimeGroup(String groupId) {
-        try (Jedis jedis = new Jedis(config.getRedisHost(), config.getRedisPort())) {
-            Set<String> ids = jedis.smembers("zmon:downtime-groups:" + groupId);
-            deleteDowntimes(ids);
-        }
+        DeleteGroupTask t = new DeleteGroupTask(groupId);
+        executor.execute(t);
     }
 
     public static class DowntimeEntry {
@@ -136,6 +140,11 @@ For now do a very stupid delete, we just assume that the id is present and delet
     }
 
     public void deleteDowntimes(final Collection<String> downtimeIds) {
+        DeleteDowntimesTask t = new DeleteDowntimesTask(downtimeIds);
+        executor.execute(t);
+    }
+
+    protected void deleteDowntimesByIds(final Collection<String> downtimeIds) {
         Map<DowntimeEntry, Collection<String>> toDeleteItems = new HashMap<>();
         try (Jedis jedis = new Jedis(config.getRedisHost(), config.getRedisPort())) {
             Set<String> alertsInDowntime = jedis.smembers("zmon:downtimes");
@@ -146,16 +155,19 @@ For now do a very stupid delete, we just assume that the id is present and delet
                 }
             }
         }
+
+        log.info("deleting individual downtime entries: count={}", toDeleteItems.size());
         doDelete(toDeleteItems);
     }
 
-    public void doDelete(Map<DowntimeEntry, Collection<String>> toDeleteEntries) {
+    protected void doDelete(Map<DowntimeEntry, Collection<String>> toDeleteEntries) {
         try (Jedis jedis = new Jedis(config.getRedisHost(), config.getRedisPort())) {
             for (Map.Entry<DowntimeEntry, Collection<String>> entry : toDeleteEntries.entrySet()) {
                 final String key = "zmon:downtimes:" + entry.getKey().alertId + ":" + entry.getKey().entity;
                 for (String id : entry.getValue()) {
                     jedis.hdel(key, id);
                 }
+
                 String type = jedis.type(key);
                 if ("none".equals(type)) {
                     jedis.srem("zmon:downtimes:" + entry.getKey().alertId, entry.getKey().entity);
@@ -163,6 +175,67 @@ For now do a very stupid delete, we just assume that the id is present and delet
                         jedis.srem("zmon:downtimes", entry.getKey().alertId);
                     }
                 }
+            }
+        }
+    }
+
+    private class DeleteDowntimesTask implements Runnable {
+
+        private final Collection<String> ids;
+
+        public DeleteDowntimesTask(Collection<String> ids) {
+            this.ids = ids;
+        }
+
+        public void delete() {
+            deleteDowntimesByIds(ids);
+        }
+
+        @Override
+        public void run() {
+            try {
+                long start = System.currentTimeMillis();
+                delete();
+                long end = System.currentTimeMillis();
+                log.info("Deleted downtimes {} in {}ms", ids, end - start);
+            }
+            catch(Throwable t) {
+                log.error("Failed delete downtimes task", t);
+            }
+        }
+    }
+
+    private class DeleteGroupTask implements Runnable {
+
+        private final String groupId;
+
+        public DeleteGroupTask(String groupId) {
+            this.groupId = groupId;
+        }
+
+        public void delete() {
+            Set<String> ids = null;
+            try (Jedis jedis = new Jedis(config.getRedisHost(), config.getRedisPort())) {
+                ids = jedis.smembers("zmon:downtime-groups:" + groupId);
+                jedis.del("zmon:downtime-groups:" + groupId);
+            }
+
+            if (null != ids) {
+                log.info("deleting downtime group: id={} count={}", groupId, ids.size());
+                deleteDowntimesByIds(ids);
+            }
+        }
+
+        @Override
+        public void run() {
+            try {
+                long start = System.currentTimeMillis();
+                delete();
+                long end = System.currentTimeMillis();
+                log.info("Deleted downtime group {} in {}ms", groupId, end - start);
+            }
+            catch(Throwable t) {
+                log.error("Failed group delete task", t);
             }
         }
     }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/downtimes/DowntimesAPI.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/downtimes/DowntimesAPI.java
@@ -2,6 +2,8 @@ package de.zalando.zmon.scheduler.ng.downtimes;
 
 import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
 import de.zalando.zmon.scheduler.ng.scheduler.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,6 +14,8 @@ import java.util.*;
  */
 @RestController
 public class DowntimesAPI {
+
+    private final Logger log = LoggerFactory.getLogger(DowntimesAPI.class);
 
     @Autowired
     Scheduler scheduler;
@@ -50,15 +54,17 @@ public class DowntimesAPI {
 
     @RequestMapping(value = "/api/v1/downtimes/{id}", method = RequestMethod.DELETE)
     void deleteDowntime(@PathVariable(value = "id") String id) {
+        log.info("Deleting downtime: id={}", id);
         Set<String> ids = new TreeSet<>();
         ids.add(id);
-        downtimeService.deleteDowntimes(ids);
         downtimeForwarder.forwardRequest(DowntimeForwardTask.DeleteDowntimeTask(ids));
+        downtimeService.deleteDowntimes(ids);
     }
 
     @RequestMapping(value = "/api/v1/downtime-groups/{groupId}", method = RequestMethod.DELETE)
     void deleteDowntimeGroup(@PathVariable(value = "groupId") String groupId) {
-        downtimeService.deleteDowntimeGroup(groupId);
+        log.info("Deleting downtime-group: groupId={}", groupId);
         downtimeForwarder.forwardRequest(DowntimeForwardTask.DeleteGroupTask(groupId));
+        downtimeService.deleteDowntimeGroup(groupId);
     }
 }


### PR DESCRIPTION
Move cleanup task to queue, to make API return.

Log more on downtime group delete.

Added cleanup task periodically for scenarios where no worker does the cleanup, e.g. federation.