### PR TITLE
Adding alert ended eventlog entry if entity gets removed.

### DIFF
--- a/src/main/java/de/zalando/zmon/scheduler/ng/config/SchedulerConfig.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/config/SchedulerConfig.java
@@ -87,6 +87,14 @@ public class SchedulerConfig {
     @Value("${server.port}")
     String serverPort  = null;
 
+    private boolean eventlogEnabled = false;
+    private String eventlogUrl = "http://localhost:8081/";
+
+    private int eventlogConnections = 50;
+    private int eventlogPoolSize = 50;
+    private int eventlogSocketTimeout = 500;
+    private int eventlogTimeout = 1000;
+
     public SchedulerConfig() {
     }
 
@@ -392,5 +400,53 @@ public class SchedulerConfig {
 
     public void setBaseFilterForward(boolean baseFilterForward) {
         this.baseFilterForward = baseFilterForward;
+    }
+
+    public boolean isEventlogEnabled() {
+        return eventlogEnabled;
+    }
+
+    public void setEventlogEnabled(boolean eventlogEnabled) {
+        this.eventlogEnabled = eventlogEnabled;
+    }
+
+    public String getEventlogUrl() {
+        return eventlogUrl;
+    }
+
+    public void setEventlogUrl(String eventlogUrl) {
+        this.eventlogUrl = eventlogUrl;
+    }
+
+    public int getEventlogConnections() {
+        return eventlogConnections;
+    }
+
+    public void setEventlogConnections(int eventlogConnections) {
+        this.eventlogConnections = eventlogConnections;
+    }
+
+    public int getEventlogPoolSize() {
+        return eventlogPoolSize;
+    }
+
+    public void setEventlogPoolSize(int eventlogPoolSize) {
+        this.eventlogPoolSize = eventlogPoolSize;
+    }
+
+    public int getEventlogSocketTimeout() {
+        return eventlogSocketTimeout;
+    }
+
+    public void setEventlogSocketTimeout(int eventlogSocketTimeout) {
+        this.eventlogSocketTimeout = eventlogSocketTimeout;
+    }
+
+    public int getEventlogTimeout() {
+        return eventlogTimeout;
+    }
+
+    public void setEventlogTimeout(int eventlogTimeout) {
+        this.eventlogTimeout = eventlogTimeout;
     }
 }

--- a/src/main/java/de/zalando/zmon/scheduler/ng/config/SingleEntityCleanupConfiguration.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/config/SingleEntityCleanupConfiguration.java
@@ -4,6 +4,7 @@ import de.zalando.zmon.scheduler.ng.alerts.AlertRepository;
 import de.zalando.zmon.scheduler.ng.checks.CheckRepository;
 import de.zalando.zmon.scheduler.ng.cleanup.SingleEntityCleanup;
 import de.zalando.zmon.scheduler.ng.entities.EntityRepository;
+import de.zalando.zmon.scheduler.ng.eventlog.HttpEventLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -17,8 +18,8 @@ public class SingleEntityCleanupConfiguration {
     private final static Logger LOG = LoggerFactory.getLogger(SingleEntityCleanupConfiguration.class);
 
     @Bean
-    SingleEntityCleanup getSingleEntityCleanup(SchedulerConfig config, AlertRepository alertRepo, CheckRepository checkRepo, EntityRepository entityRepository) {
-        SingleEntityCleanup cleanup = new SingleEntityCleanup(config, alertRepo, checkRepo, entityRepository);
+    SingleEntityCleanup getSingleEntityCleanup(SchedulerConfig config, AlertRepository alertRepo, CheckRepository checkRepo, EntityRepository entityRepository, HttpEventLogger eventLog) {
+        SingleEntityCleanup cleanup = new SingleEntityCleanup(config, alertRepo, checkRepo, entityRepository, eventLog);
         LOG.info("Registering SingleEntityCleanUp job");
         entityRepository.registerListener(cleanup);
         return cleanup;

--- a/src/main/java/de/zalando/zmon/scheduler/ng/eventlog/EventType.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/eventlog/EventType.java
@@ -1,0 +1,16 @@
+package de.zalando.zmon.scheduler.ng.eventlog;
+
+import java.util.List;
+
+/**
+ * Created by jmussler on 10.06.16.
+ */
+public interface EventType {
+
+    int getId();
+
+    String getName();
+
+    List<String> getFieldNames();
+
+}

--- a/src/main/java/de/zalando/zmon/scheduler/ng/eventlog/HttpEventLogger.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/eventlog/HttpEventLogger.java
@@ -1,0 +1,119 @@
+package de.zalando.zmon.scheduler.ng.eventlog;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import de.zalando.zmon.scheduler.ng.config.SchedulerConfig;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.fluent.Async;
+import org.apache.http.client.fluent.Content;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Created by jmussler on 10.06.16.
+ */
+@Component
+public class HttpEventLogger {
+
+    private final boolean enabled;
+
+    private final String forwardUrl;
+    private final Executor executor;
+
+    private final Meter eventlogErrorMeter;
+    private final Async async;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Logger log = LoggerFactory.getLogger(HttpEventLogger.class);
+
+    private static class HttpEvent {
+        public Map<String, Object> attributes;
+
+        public Date time;
+        public int typeId;
+
+        public HttpEvent(Date time, EventType type, Object[] values) {
+            this.time = time;
+            this.typeId = type.getId();
+            this.attributes = new TreeMap<>();
+
+            for (int i = 0; i < type.getFieldNames().size(); ++i) {
+                if (i < values.length) {
+                    attributes.put(type.getFieldNames().get(i), values[i]);
+                } else {
+                    attributes.put(type.getFieldNames().get(i), null);
+                }
+            }
+        }
+    }
+
+    public static HttpClient getHttpClient(int socketTimeout, int timeout, int maxConnections) {
+        RequestConfig config = RequestConfig.custom().setSocketTimeout(socketTimeout).setConnectTimeout(timeout).build();
+        return HttpClients.custom().setMaxConnPerRoute(maxConnections).setMaxConnTotal(maxConnections).setDefaultRequestConfig(config).build();
+    }
+
+    @Autowired
+    public HttpEventLogger(MetricRegistry metrics, SchedulerConfig config) {
+        this.eventlogErrorMeter = metrics.meter("scheduler.eventlog.errorMeter");
+        enabled = config.isEventlogEnabled();
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        if (enabled) {
+            forwardUrl = config.getEventlogUrl() + "/api/v1";
+            log.info("EventLog enabled: {}", forwardUrl);
+            executor = Executor.newInstance(getHttpClient(config.getEventlogSocketTimeout(), config.getEventlogTimeout(), config.getEventlogConnections()));
+            ExecutorService threadPool = Executors.newFixedThreadPool(config.getEventlogPoolSize());
+            async = Async.newInstance().use(threadPool).use(executor);
+        } else {
+            log.info("EventLog disabled");
+            forwardUrl = null;
+            async = null;
+            executor = null;
+        }
+    }
+
+    public void log(EventType type, Object... values) {
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            Request request = Request.Post(forwardUrl + "/")
+                    .bodyString("[" + mapper.writeValueAsString(new HttpEvent(new Date(), type, values)) + "]", ContentType.APPLICATION_JSON);
+
+            async.execute(request, new FutureCallback<Content>() {
+
+                public void failed(final Exception ex) {
+                    eventlogErrorMeter.mark();
+                }
+
+                public void completed(final Content content) {
+                }
+
+                public void cancelled() {
+                }
+
+            });
+        } catch (Throwable t) {
+            log.error("EventLog write failed: {}", t.getMessage());
+            eventlogErrorMeter.mark();
+        }
+    }
+}

--- a/src/main/java/de/zalando/zmon/scheduler/ng/eventlog/ZMonEventType.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/eventlog/ZMonEventType.java
@@ -1,0 +1,57 @@
+package de.zalando.zmon.scheduler.ng.eventlog;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum ZMonEventType implements EventType {
+
+    // worker events
+    ALERT_STARTED(0x34001, "checkId", "alertId", "value"),
+    ALERT_ENDED(0x34002, "checkId", "alertId", "value"),
+    ALERT_ENTITY_STARTED(0x34003, "checkId", "alertId", "value", "entity"),
+    ALERT_ENTITY_ENDED(0x34004, "checkId", "alertId", "value", "entity"),
+    DOWNTIME_STARTED(0x34005, "alertId", "entity", "startTime", "endTime", "userName", "comment"),
+    DOWNTIME_ENDED(0x34006, "alertId", "entity", "startTime", "endTime", "userName", "comment"),
+
+    // controller events
+    DOWNTIME_SCHEDULED(0x34101, "alertId", "entity", "startTime", "endTime", "userName", "comment"),
+    DOWNTIME_REMOVED(0x34102, "alertId", "entity", "startTime", "endTime", "userName", "comment"),
+    TRIAL_RUN_SCHEDULED(0x34103, "checkCommand", "alertCondition", "entities", "period", "userName"),
+    ALERT_COMMENT_CREATED(0x34104, "commentId", "comment", "alertId", "entity", "userName"),
+    ALERT_COMMENT_REMOVED(0x34105, "commentId", "comment", "alertId", "entity", "userName"),
+    CHECK_DEFINITION_CREATED(0x34106, "checkId", "entities", "checkCommand", "userName"),
+    CHECK_DEFINITION_UPDATED(0x34107, "checkId", "entities", "checkCommand", "userName"),
+    ALERT_DEFINITION_CREATED(0x34108, "alertId", "entities", "alertCondition", "userName"),
+    ALERT_DEFINITION_UPDATED(0x34109, "alertId", "entities", "alertCondition", "userName"),
+    CHECK_DEFINITION_DELETED(0x3410a, "checkId", "entities", "checkCommand", "userName"),
+    ALERT_DEFINITION_DELETED(0x3410b, "alertId", "entities", "alertCondition", "userName"),
+    DASHBOARD_CREATED(0x3410c, "dashboardId", "name", "widgetConfiguration", "alertTeams", "viewMode", "editOption",
+            "sharedTeams", "userName"),
+    DASHBOARD_UPDATED(0x3410d, "dashboardId", "name", "widgetConfiguration", "alertTeams", "viewMode", "editOption",
+            "sharedTeams", "userName"),
+    INSTANTANEOUS_ALERT_EVALUATION_SCHEDULED(0x3410e, "alertId", "userName"),
+    GROUP_MODIFIED(0x3410f, "userName", "action","group","member","phone");
+
+    private final int id;
+    private final List<String> fieldNames;
+
+    private ZMonEventType(final int id, final String... fieldNames) {
+        this.id = id;
+        this.fieldNames = Arrays.asList(fieldNames);
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public List<String> getFieldNames() {
+        return fieldNames;
+    }
+}


### PR DESCRIPTION
Solve long standing issue of not having events in ui for entities that have been removed via the agent.

E.g. Auto Scaling on AWS