### PR TITLE
jaeger instrumentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,27 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-web-autoconfigure</artifactId>
+            <version>0.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.uber.jaeger</groupId>
+            <artifactId>jaeger-core</artifactId>
+            <version>0.20.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.brave</groupId>
+            <artifactId>brave-opentracing</artifactId>
+            <version>0.21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jdbc</artifactId>
+            <version>0.0.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/de/zalando/zmon/scheduler/ng/Application.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/Application.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.web.bind.annotation.*;
 
 import javax.net.ssl.SSLSession;
@@ -30,6 +31,10 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+
+import com.uber.jaeger.Configuration;
+import com.uber.jaeger.samplers.ProbabilisticSampler;
 
 @RestController
 @EnableConfigurationProperties
@@ -160,6 +165,16 @@ public class Application {
         node.put("check-repo", checkRepo.getLastUpdated());
         node.put("entity-repo", entityRepo.getLastUpdated());
         return node;
+    }
+
+    @Bean
+    public io.opentracing.Tracer jaegerTracer() {
+
+        Configuration config = Configuration.fromEnv();
+
+        io.opentracing.Tracer tracer = config.getTracer();
+
+        return tracer;
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
opentracing java instrumentation using Jaeger tracer. The configurations are loaded though environment variables.

          JAEGER_SERVICE_NAME: "zmon-notification-service"
          JAEGER_AGENT_HOST: "jaeger"
          JAEGER_AGENT_PORT: 5775
          JAEGER_REPORTER_LOG_SPANS: "true"
          JAEGER_REPORTER_MAX_QUEUE_SIZE: 100
          JAEGER_TAGS: "opentracing=poc"
          JAEGER_REPORTER_FLUSH_INTERVAL: 100
          JAEGER_SAMPLER_TYPE: "probabilistic"
          JAEGER_SAMPLER_PARAM: 1