### PR TITLE
do not use shell during startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM registry.opensource.zalan.do/stups/openjdk:latest
 EXPOSE 8085
 
 COPY target/zmon-scheduler-1.0-SNAPSHOT.jar /zmon-scheduler.jar
-
-CMD java $JAVA_OPTS $(java-dynamic-memory-opts) -jar zmon-scheduler.jar
+COPY start.sh /start.sh
+RUN chmod 755 /start.sh
+CMD ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec java $JAVA_OPTS $(java-dynamic-memory-opts) -jar zmon-scheduler.jar


### PR DESCRIPTION
for the k8s vertical pod autoscaler the java process needs to be PID 1
to work correctly