### PR TITLE
put skipField back into EntityRepository

### DIFF
--- a/src/main/java/de/zalando/zmon/scheduler/ng/entities/EntityRepository.java
+++ b/src/main/java/de/zalando/zmon/scheduler/ng/entities/EntityRepository.java
@@ -58,7 +58,7 @@ public class EntityRepository extends CachedRepository<String, EntityAdapterRegi
     public EntityRepository(EntityAdapterRegistry registry, SchedulerConfig config, Tracer tracer) {
         super(registry, tracer);
 
-        this.skipField = config.EntitySkipOnField();
+        this.skipField = config.getEntitySkipOnField();
         this.redisHost = config.getRedisHost();
         this.redisPort = config.getRedisPort();
         this.redisPropertiesKey = config.getEntityPropertiesKey();


### PR DESCRIPTION
this is still required in this place for a setup where k8s and an
appliance is running....

This does not affect the other usage as those entites are skipped
before and not downloaded